### PR TITLE
propagate W3C trace context across BFF → auth

### DIFF
--- a/services/auth/Cargo.lock
+++ b/services/auth/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "axum 0.8.8",
  "axum-login",
  "axum-prometheus",
+ "axum-tracing-opentelemetry",
  "chrono",
  "dotenvy",
  "jsonwebtoken",
@@ -114,7 +115,6 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
- "tower-http",
  "tower-sessions",
  "tower-sessions-sqlx-store",
  "tracing",
@@ -280,6 +280,24 @@ dependencies = [
  "tokio",
  "tower 0.5.3",
  "tower-http",
+]
+
+[[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b722ea45bf47f9fe55c9aac9ca7122e0fea5edb85dced4f6ec411c42fbec5"
+dependencies = [
+ "axum 0.8.8",
+ "futures-core",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
 ]
 
 [[package]]
@@ -3122,7 +3140,6 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3262,6 +3279,18 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf359b8862d097418bc1a3edd0ab8a1700dc155258557195b29d96fde14c5a8"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/services/auth/Cargo.toml
+++ b/services/auth/Cargo.toml
@@ -26,7 +26,6 @@ reqwest = { version = "^0.12.28", features = ["json"] }
 serde_json = "1.0.149"
 tower-sessions-sqlx-store = { version = "0.15.0", features = ["postgres"] }
 tower-sessions = { version = "0.14.0", features = ["axum-core"] }
-tower-http = { version = "0.6", features = ["trace"] }
 jsonwebtoken = "9"
 ulid = "1"
 
@@ -39,3 +38,4 @@ opentelemetry = "0.27"
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
 tracing-opentelemetry = "0.28"
+axum-tracing-opentelemetry = "0.25"

--- a/services/auth/src/auth.rs
+++ b/services/auth/src/auth.rs
@@ -11,7 +11,7 @@ use std::{env, panic};
 
 use axum::{Router, routing::get};
 use axum_prometheus::PrometheusMetricLayer;
-use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
+use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 use axum_login::{
     AuthManagerLayerBuilder,
     tower_sessions::{
@@ -120,11 +120,11 @@ impl Auth {
             .merge(permissions::router())
             .merge(core::router())
             .layer(auth_layer)
-            .layer(
-                TraceLayer::new_for_http()
-                    .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
-                    .on_response(DefaultOnResponse::new().level(tracing::Level::INFO)),
-            )
+            // OtelInResponseLayer must sit *outside* OtelAxumLayer so the response
+            // header (`traceresponse`) is added after the inner layer has populated
+            // the OTel context for the request span.
+            .layer(OtelInResponseLayer)
+            .layer(OtelAxumLayer::default())
             .layer(prometheus_layer);
 
         let listener = match tokio::net::TcpListener::bind(format!(

--- a/services/frontend/Cargo.lock
+++ b/services/frontend/Cargo.lock
@@ -64,6 +64,8 @@ dependencies = [
  "http",
  "jsonwebtoken",
  "reqwest 0.13.3",
+ "reqwest-middleware",
+ "reqwest-tracing",
  "serde",
  "serde_json",
  "tower-sessions",
@@ -424,6 +426,24 @@ dependencies = [
  "tokio",
  "tower 0.5.3",
  "tower-http",
+]
+
+[[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b722ea45bf47f9fe55c9aac9ca7122e0fea5edb85dced4f6ec411c42fbec5"
+dependencies = [
+ "axum 0.8.9",
+ "futures-core",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
 ]
 
 [[package]]
@@ -5268,6 +5288,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c1a1510677d43dce9e9c0c07fc5db8772c0e5a43e4f9cef75a11affa05a578"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.17",
+ "http",
+ "matchit 0.8.4",
+ "opentelemetry",
+ "reqwest 0.13.3",
+ "reqwest-middleware",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
 name = "rfd"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6648,6 +6700,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf359b8862d097418bc1a3edd0ab8a1700dc155258557195b29d96fde14c5a8"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7080,6 +7144,7 @@ dependencies = [
  "api",
  "axum 0.8.9",
  "axum-prometheus",
+ "axum-tracing-opentelemetry",
  "dioxus",
  "dotenvy",
  "getrandom 0.2.17",
@@ -7088,7 +7153,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "tower-http",
  "tower-sessions",
  "tower-sessions-redis-store",
  "tracing",

--- a/services/frontend/packages/api/Cargo.toml
+++ b/services/frontend/packages/api/Cargo.toml
@@ -15,7 +15,7 @@ jsonwebtoken = { workspace = true }
 http = "1"
 tracing = { workspace = true }
 tower-sessions = { workspace = true, optional = true }
-reqwest-middleware = { version = "0.5", optional = true }
+reqwest-middleware = { version = "0.5", features = ["json"], optional = true }
 reqwest-tracing = { version = "0.7", features = ["opentelemetry_0_27"], optional = true }
 
 [features]

--- a/services/frontend/packages/api/Cargo.toml
+++ b/services/frontend/packages/api/Cargo.toml
@@ -15,6 +15,13 @@ jsonwebtoken = { workspace = true }
 http = "1"
 tracing = { workspace = true }
 tower-sessions = { workspace = true, optional = true }
+reqwest-middleware = { version = "0.5", optional = true }
+reqwest-tracing = { version = "0.7", features = ["opentelemetry_0_27"], optional = true }
 
 [features]
-server = ["dioxus/server", "dep:tower-sessions"]
+server = [
+    "dioxus/server",
+    "dep:tower-sessions",
+    "dep:reqwest-middleware",
+    "dep:reqwest-tracing",
+]

--- a/services/frontend/packages/api/src/lib.rs
+++ b/services/frontend/packages/api/src/lib.rs
@@ -28,6 +28,22 @@ mod session {
     }
 }
 
+// Shared HTTP client wrapped with reqwest-tracing middleware so every outbound
+// request to the auth service injects W3C `traceparent` from the current span.
+// Using a process-wide client also reuses the connection pool across calls.
+#[cfg(feature = "server")]
+fn http_client() -> &'static reqwest_middleware::ClientWithMiddleware {
+    use std::sync::OnceLock;
+    use reqwest_middleware::ClientBuilder;
+    use reqwest_tracing::TracingMiddleware;
+    static CLIENT: OnceLock<reqwest_middleware::ClientWithMiddleware> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        ClientBuilder::new(reqwest::Client::new())
+            .with(TracingMiddleware::default())
+            .build()
+    })
+}
+
 // ---- Plain async helpers for Axum OAuth handlers in the web crate ----
 
 /// Ask the auth service to begin an OAuth flow. Returns `(auth_url, csrf_state)`.
@@ -45,7 +61,7 @@ pub async fn start_oauth(provider: &str) -> Result<(String, String), String> {
         state: String,
     }
 
-    let resp = reqwest::Client::new()
+    let resp = http_client()
         .post(format!("{}/internal/oauth/start", auth_url()))
         .header("x-service-token", service_secret())
         .json(&Req { provider })
@@ -80,7 +96,7 @@ pub async fn exchange_oauth_code(
         username: String,
     }
 
-    let resp = reqwest::Client::new()
+    let resp = http_client()
         .post(format!("{}/internal/oauth/exchange", auth_url()))
         .header("x-service-token", service_secret())
         .json(&Req { provider, code })
@@ -126,7 +142,7 @@ pub async fn login_password(
         username: String,
     }
 
-    let resp = reqwest::Client::new()
+    let resp = http_client()
         .post(format!("{}/internal/token/exchange", auth_url()))
         .header("x-service-token", service_secret())
         .json(&Req { username: username.clone(), password })
@@ -213,7 +229,7 @@ pub async fn register_password(
         username: String,
     }
 
-    let resp = reqwest::Client::new()
+    let resp = http_client()
         .post(format!("{}/internal/register", auth_url()))
         .header("x-service-token", service_secret())
         .json(&Req { username: username.clone(), email, password })
@@ -278,7 +294,7 @@ pub async fn get_my_permissions() -> Result<Vec<String>, ServerFnError> {
         permissions: Vec<String>,
     }
 
-    let resp = reqwest::Client::new()
+    let resp = http_client()
         .post(format!("{}/internal/token/introspect", auth_url()))
         .header("x-service-token", service_secret())
         .json(&Req { token })
@@ -323,7 +339,7 @@ pub async fn ark_player_count() -> Result<i32, ServerFnError> {
         token: String,
     }
 
-    let resp = reqwest::Client::new()
+    let resp = http_client()
         .post(format!("{}/internal/ark/num_players", auth_url()))
         .header("x-service-token", service_secret())
         .json(&Req { token })
@@ -366,7 +382,7 @@ pub async fn ark_command(cmd: String) -> Result<CommandResult, ServerFnError> {
         cmd: String,
     }
 
-    let resp = reqwest::Client::new()
+    let resp = http_client()
         .post(format!("{}/internal/ark/command", auth_url()))
         .header("x-service-token", service_secret())
         .json(&Req { token, cmd })

--- a/services/frontend/packages/web/Cargo.toml
+++ b/services/frontend/packages/web/Cargo.toml
@@ -17,13 +17,13 @@ axum = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tower-http = { version = "0.6", features = ["trace"] }
 
 # Distributed tracing (OTLP → Alloy → Tempo)
 opentelemetry = "0.27"
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.27", features = ["grpc-tonic"] }
 tracing-opentelemetry = "0.28"
+axum-tracing-opentelemetry = "0.25"
 
 # Metrics (Prometheus exposition format → Alloy → Mimir)
 axum-prometheus = "0.10"

--- a/services/frontend/packages/web/src/main.rs
+++ b/services/frontend/packages/web/src/main.rs
@@ -36,13 +36,13 @@ fn main() {
 fn server_launch() -> ! {
     use axum::{routing::get, Router};
     use axum_prometheus::PrometheusMetricLayer;
+    use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
     use opentelemetry::KeyValue;
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_otlp::WithExportConfig;
     use opentelemetry_sdk::{
         Resource, runtime::Tokio as OtelTokio, trace::TracerProvider as SdkTracerProvider,
     };
-    use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
     use tower_sessions::cookie::time::Duration;
     use tower_sessions::cookie::SameSite;
     use tower_sessions::{Expiry, SessionManagerLayer};
@@ -125,11 +125,11 @@ fn server_launch() -> ! {
                 .route("/oauth/callback/{provider}", get(oauth_callback))
                 .route("/metrics", get(move || async move { metric_handle.render() }))
                 .layer(layer)
-                .layer(
-                    TraceLayer::new_for_http()
-                        .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
-                        .on_response(DefaultOnResponse::new().level(tracing::Level::INFO)),
-                )
+                // OtelInResponseLayer must sit *outside* OtelAxumLayer so the
+                // `traceresponse` header is added after the inner layer has
+                // populated the OTel context for the request span.
+                .layer(OtelInResponseLayer)
+                .layer(OtelAxumLayer::default())
                 .layer(prometheus_layer);
             Ok(router)
         }


### PR DESCRIPTION
So far each service started its own trace, so frontend and auth spans showed up as separate traces in Tempo. Add OtelAxumLayer + OtelInResponseLayer on both axum routers (extracts traceparent on inbound, emits traceresponse on outbound), and wrap the api crate's reqwest client with reqwest-tracing's TracingMiddleware so outbound BFF → auth calls inject traceparent from the current span context.

Drops the now-redundant tower-http TraceLayer and its dep.